### PR TITLE
fix upload path for Windows

### DIFF
--- a/bin/comprehend-ssie-annotation-tool-cli.py
+++ b/bin/comprehend-ssie-annotation-tool-cli.py
@@ -55,6 +55,7 @@ def upload_object(content, path, s3_client):
 
 def upload_directory(path, bucket_name, s3_path_prefix, s3_client):
     for root, dirs, files in os.walk(path):
+        root = root.replace("\\", "/")
         for file in files:
             extra_args = {}
             content_type = mimetypes.guess_type(file)[0]


### PR DESCRIPTION
Windows paths contain backslash which have to be replace by forward slash otherwise the upload path of ui template files in S3 will be incorrect.